### PR TITLE
Remove old server that no longer exists

### DIFF
--- a/sans.py
+++ b/sans.py
@@ -779,15 +779,14 @@ async def wii(ctx):
 
 @bot.command()
 async def invite(ctx, invite):
-    '''Shows the invites for various discord guilds (ivan, homebrew, analog, chill)'''
+    '''Shows the invites for various discord guilds (ivan, homebrew, chill)'''
     invites = {
         "ivan": "NM85JqJ",
         "chill": "eTS6yym",
-        "analog": "7bXpJSh",
         "homebrew": "C29hYvh"
     }
     try:    await ctx.send(f"https://discord.gg/{invites[invite.lower()]}")
-    except: await ctx.send('Options are: ivan, homebrew, analog, chill.')
+    except: await ctx.send('Options are: ivan, homebrew, chill.')
 
 @bot.command()
 async def serial(ctx):


### PR DESCRIPTION
I noticed this and now it's the only thing I can think about, so I had to make a PR that fixes it. Removes the "analog" entry from the invite list, since the server doesn't exist anymore.